### PR TITLE
Fix slice warning from logs

### DIFF
--- a/lib/trailing_slash_plug.ex
+++ b/lib/trailing_slash_plug.ex
@@ -26,7 +26,7 @@ defmodule TrailingSlashPlug do
     path = conn.request_path
 
     if String.ends_with?(path, "/") && path != "/" do
-      new_path = String.slice(path, 0..-2//-1)
+      new_path = String.slice(path, 0..-2//1)
 
       conn
       |> put_status(301)


### PR DESCRIPTION
This PR fixes the warning 
```
(elixir 1.18.4) lib/string.ex:2427: String.slice/2
warning: negative steps are not supported in String.slice/2, pass 0..-2//1 instead
```