### PR TITLE
ci(bot): run github actions dependabot updates weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-    interval: "monthly"
+    interval: "weekly"
   open-pull-requests-limit: 99
   assignees:
   - samhamilton


### PR DESCRIPTION
_No JIRA ticket — automated CI / dependency-management change (`bot` scope)._

## Why

The `github-actions` ecosystem moves from `monthly` to `weekly`, so action updates — including
security-relevant ones — land within a week instead of up to a month. Every other ecosystem in this
repo keeps its existing cadence.

## Change Type

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Testing

- `actionlint` — clean on every changed workflow (only the known custom `martide-runner-set` label is reported).
- All changed `.yml` files parse as YAML.
- Every SHA in the diff was verified against the upstream tag list via `GET /repos/{owner}/{repo}/tags`.

## Code Quality

- [ ] Added docs
- [ ] Added specs
